### PR TITLE
Update Release_arm64.gn

### DIFF
--- a/Release_arm64.gn
+++ b/Release_arm64.gn
@@ -10,3 +10,4 @@ media_use_ffmpeg = true
 media_use_libvpx = true
 proprietary_codecs = true
 ffmpeg_branding = "Chrome"
+chrome_pgo_phase = 0


### PR DESCRIPTION
Official builds require chrome_pgo_phase to be set to 0. The error message didn't help so wanted to keep this by default.